### PR TITLE
Set compiler warnings to max, resolve warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-CC = gcc
+# Turn on all warnings except missing-braces
+# (no-missing-braces is for protoc generated code)
+CC = gcc -Wall -Wextra -Wno-missing-braces
 AR = ar rc
 
 DIRs += $(shell find ./src -maxdepth 3 -type d)

--- a/sample/CsmpAgentLib_sample.c
+++ b/sample/CsmpAgentLib_sample.c
@@ -420,7 +420,7 @@ void* firmware_image_info_get(uint32_t *num) {
 
   g_firmwareImageInfo.index = 1;
   g_firmwareImageInfo.filehash.len = 32;
-  sprintf(g_firmwareImageInfo.filehash.data, "12345");
+  sprintf((char *)g_firmwareImageInfo.filehash.data, "12345");
   sprintf(g_firmwareImageInfo.filename, "vendor firmware");
   sprintf(g_firmwareImageInfo.version, "1.0.0");
   g_firmwareImageInfo.filesize = 246272;
@@ -656,3 +656,4 @@ int main(int argc, char **argv)
 start_error:
   printf("start csmp agent service: fail!\n");
 }
+

--- a/sample/Makefile
+++ b/sample/Makefile
@@ -1,5 +1,5 @@
 #define your own gcc here if you need cross-compile the code
-CC = gcc
+CC = gcc -Wall -Wextra
 
 CFLAGS += -I ../include
 LIBS += -lpthread

--- a/sample/signature_verify.c
+++ b/sample/signature_verify.c
@@ -113,6 +113,11 @@ bool signature_verify(const void *data, size_t datalen, const void *sig, size_t 
   }
 
 #else
+  // Temporary stub for first release.
+  (void)data;
+  (void)datalen;
+  (void)sig;
+  (void)siglen;
   return true;
 #endif
 }

--- a/src/coap/coapclient.c
+++ b/src/coap/coapclient.c
@@ -41,7 +41,7 @@ static bool m_client_opened = false;
 static uint16_t m_transaction_id = 0;
 static pthread_t recvt_id;
 
-void *recv_fn(void *arg);
+void *recv_fn(void*);
 int write_option( uint8_t *buf, uint16_t buf_len, coap_option_t this_option, coap_option_t *last_option,
     const uint8_t* option_buf, uint32_t option_len, uint32_t *written_len );
 void process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from);
@@ -56,7 +56,6 @@ int coapclient_stop()
 
 int coapclient_open(response_handler_t response_handler)
 {
-  int rv;
   int sockfd;
 
   if (m_client_opened) {
@@ -77,7 +76,7 @@ int coapclient_open(response_handler_t response_handler)
 
   m_sock = sockfd;
   m_client_opened = true;
-  rv = pthread_create(&recvt_id, NULL, recv_fn, NULL);
+  pthread_create(&recvt_id, NULL, recv_fn, NULL);
   pthread_detach(recvt_id);
   return 0;
 }
@@ -103,7 +102,7 @@ int coapclient_request (const struct sockaddr_in6 *to,
 
   coap_option_t last_option = (coap_option_t)0;
   uint32_t written_len = 0;
-  int j = 0;
+  uint32_t j = 0;
 
   if (url) {
     for (j=0; j < url_cnt; j++) {
@@ -249,7 +248,7 @@ void coap_option_map(uint32_t val, uint8_t *map)
     *map = 14;
 }
 
-void *recv_fn(void *arg)
+void *recv_fn(void*)
 {
   DPRINTF("coapclient receive thread is serving now...\n");
 
@@ -314,14 +313,14 @@ void process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from)
   uint8_t status_detail;
   uint16_t status, buf_used = 0;
   uint32_t option_delta, option_len;
-  if ( (len - buf_used) < sizeof(coap_header_t) )
+  if ( (len - buf_used) < (uint16_t)sizeof(coap_header_t) )
     return;
 
   hdr = (coap_header_t*) cur;
 
   tkl = hdr->control & 0xF;
 
-  if ((len - buf_used) < (sizeof(coap_header_t) + tkl) || tkl > COAP_MAX_TKL)
+  if ((len - buf_used) < ((uint16_t)sizeof(coap_header_t) + tkl) || tkl > COAP_MAX_TKL)
     return;
 
   status_class = (hdr->code >> 5);
@@ -374,7 +373,7 @@ void process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from)
       break;
     }
 
-    if ((len - buf_used) < option_len)
+    if ((uint32_t)(len - buf_used) < option_len)
       return;
 
     cur += option_len; buf_used += option_len;

--- a/src/csmpagent/csmp_currenttime.c
+++ b/src/csmpagent/csmp_currenttime.c
@@ -21,9 +21,8 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
-  struct timeval tv = {0};
   size_t rv = 0;
   uint32_t num;
 
@@ -58,7 +57,7 @@ int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvind
   }
 }
 
-int csmp_put_currenttime(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_currenttime(tlvid_t tlvid, const uint8_t *buf, size_t len)
 {
   CurrentTime *CurrentTimeMsg = NULL;
   Current_Time current_time = CURRENT_TIME_INIT;

--- a/src/csmpagent/csmp_deviceid.c
+++ b/src/csmpagent/csmp_deviceid.c
@@ -24,7 +24,7 @@
 
 extern uint8_t g_csmplib_eui64[8];
 
-int csmp_get_deviceid(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_deviceid(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   char id[128];

--- a/src/csmpagent/csmp_firmwareImageInfo.c
+++ b/src/csmpagent/csmp_firmwareImageInfo.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_firmwareImageInfo(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_firmwareImageInfo(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t num;

--- a/src/csmpagent/csmp_group.c
+++ b/src/csmpagent/csmp_group.c
@@ -24,14 +24,14 @@
 static uint32_t m_GroupIds[CSMP_GROUP_NUM_TYPES] = {0};
 static bool m_bLastMatchValid;
 
-bool checkGroup(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcaddr) {
+bool checkGroup(const uint8_t *buf, uint32_t len) {
   uint32_t msglen;
   tlvid_t tlvid = {0,GROUP_MATCH_TLVID};
   const uint8_t *pctlv = csmptlv_find(buf,len,tlvid,&msglen);
   int rv;
 
   if (pctlv) {
-    rv = csmpagent_post(tlvid, pctlv, msglen,NULL,0,NULL,0,srcaddr);
+    rv = csmpagent_post(tlvid, pctlv, msglen,NULL,0,NULL,0);
     if (rv == 0) {
       return false;
     }
@@ -48,7 +48,7 @@ bool checkGroup(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcaddr) 
   return true;
 }
 
-int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   GroupAssign GroupAssignMsg = GROUP_ASSIGN__INIT;
   uint8_t *pbuf = buf;
@@ -79,8 +79,7 @@ int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvind
   return used;
 }
 
-int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf,
-                         size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len)
 {
   GroupAssign *GroupAssignMsg = NULL;
   tlvid_t tlvid0;
@@ -121,8 +120,7 @@ int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t 
   return used;
 }
 
-int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf,
-                         size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len)
 {
   GroupMatch *GroupMatchMsg = NULL;
   tlvid_t tlvid0;
@@ -163,7 +161,7 @@ int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *
 
 }
 
-int csmp_get_groupInfo(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_groupInfo(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   GroupInfo GroupInfoMsg = GROUP_INFO__INIT;
   uint8_t *pbuf = buf;

--- a/src/csmpagent/csmp_hardwareDesc.c
+++ b/src/csmpagent/csmp_hardwareDesc.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_hardwareDesc(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_hardwareDesc(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t num;

--- a/src/csmpagent/csmp_interfaceDesc.c
+++ b/src/csmpagent/csmp_interfaceDesc.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_interfaceDesc(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_interfaceDesc(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmp_interfaceMetrics.c
+++ b/src/csmpagent/csmp_interfaceMetrics.c
@@ -21,7 +21,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_interfaceMetrics(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_interfaceMetrics(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmp_ipAddress.c
+++ b/src/csmpagent/csmp_ipAddress.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipAddress(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_ipAddress(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmp_ipRoute.c
+++ b/src/csmpagent/csmp_ipRoute.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipRoute(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_ipRoute(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmp_ipRouteRplMetrics.c
+++ b/src/csmpagent/csmp_ipRouteRplMetrics.c
@@ -21,10 +21,10 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipRouteRplMetrics(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_ipRouteRplMetrics(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
-  uint32_t i, num;
+  uint32_t num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 

--- a/src/csmpagent/csmp_reportSubscribe.c
+++ b/src/csmpagent/csmp_reportSubscribe.c
@@ -27,10 +27,10 @@
 
 csmp_subscription_list_t g_csmplib_report_list;
 
-int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   ReportSubscribe ReportSubscribeMsg = REPORT_SUBSCRIBE__INIT;
-  int i;
+  uint32_t i;
   uint8_t *pbuf = buf;
   size_t rv, used = 0;
   char **tlvlist = NULL;
@@ -65,7 +65,7 @@ int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tl
   return used;
 }
 
-int csmp_put_reportSubscribe(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_reportSubscribe(const uint8_t *buf, size_t len)
 {
   ReportSubscribe *ReportSubscribeMsg = NULL;
   tlvid_t tlvid0;
@@ -74,7 +74,7 @@ int csmp_put_reportSubscribe(tlvid_t tlvid, const uint8_t *buf, size_t len, uint
   const uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
-  int i;
+  long unsigned int i;
 
   DPRINTF("Received POST reportSubscribe TLV\n");
 

--- a/src/csmpagent/csmp_rplInstance.c
+++ b/src/csmpagent/csmp_rplInstance.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_rplInstance(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_rplInstance(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmp_sessionId.c
+++ b/src/csmpagent/csmp_sessionId.c
@@ -23,7 +23,7 @@
 static SessionID gSessionIDVal = SESSION_ID__INIT;
 static char sessionID[17] = {0};
 
-int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
 
@@ -42,7 +42,7 @@ int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex
   }
 }
 
-int csmp_put_sessionID(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_sessionID(const uint8_t *buf, size_t len)
 {
   SessionID *SessionIDMsg = NULL;
   tlvid_t tlvid0;

--- a/src/csmpagent/csmp_signature.c
+++ b/src/csmpagent/csmp_signature.c
@@ -25,26 +25,26 @@ static Signature g_SigMsg = SIGNATURE__INIT;
 static SignatureValidity g_SigValidityMsg = SIGNATURE_VALIDITY__INIT;
 static uint8_t signature_data[88] = {0};
 
-int checkSignature(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcaddr) {
-  tlvid_t tlvid = {0,SIGNATURE_TLVID};
-  uint32_t msglen, seclen;
+
+int checkSignature(const uint8_t *buf, uint32_t len) {
+
+#if 0
   const uint8_t *ptlv;
+  uint32_t seclen;
   int rv;
   struct timeval tv = {0};
   uint8_t *sig = NULL;
   uint8_t *sigend = NULL;
   size_t siglen;
 
-  return 1;
-
-#if 0 // ignore signature check for first release
   ptlv = csmptlv_find(buf,len,tlvid,&msglen);
+
   if (!ptlv) {
     DPRINTF("CsmpServer: Cannot locate required Signature TLV\n");
     return 0;
   }
 
-  rv = csmpagent_post(tlvid, ptlv, msglen,NULL,0,NULL,0,srcaddr);
+  rv = csmpagent_post(tlvid, ptlv, msglen,NULL,0,NULL,0);
   if (rv == 0) {
     DPRINTF("CsmpServer: Problem parsing Signature TLV\n");
     return -1;
@@ -59,7 +59,7 @@ int checkSignature(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcadd
       DPRINTF("CsmpServer: Cannot locate required SignatureValidity TLV\n");
       return -1;
     }
-    rv = csmpagent_post(tlvid, ptlv, msglen,NULL,0,NULL,0,srcaddr);
+    rv = csmpagent_post(tlvid, ptlv, msglen,NULL,0,NULL,0);
     if (rv == 0) {
       DPRINTF("CsmpServer: Problem parsing SignatureValidity TLV\n");
       return -1;
@@ -109,11 +109,16 @@ int checkSignature(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcadd
     DPRINTF("CsmpServer: invalid time \n");
     return -1;
   }
+#else
+  // Temporary for first release.
+  tlvid_t tlvid = {0,SIGNATURE_TLVID};
+  uint32_t msglen;
+  csmptlv_find(buf,len,tlvid,&msglen);
+  return 1;
 #endif
 }
 
-
-int csmp_put_signature(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_signature(const uint8_t *buf, size_t len)
 {
   Signature *SignatureMsg = NULL;
   tlvid_t tlvid0;
@@ -147,7 +152,7 @@ int csmp_put_signature(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *o
   return used;
 }
 
-int csmp_put_signatureValidity(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
+int csmp_put_signatureValidity(const uint8_t *buf, size_t len)
 {
   SignatureValidity *SignatureValidityMsg = NULL;
   tlvid_t tlvid0;

--- a/src/csmpagent/csmp_tlvindex.c
+++ b/src/csmpagent/csmp_tlvindex.c
@@ -43,10 +43,8 @@ static char *ptlvs[NUM_TLVS] = {
   FIRMWARE_IMAGE_INFO_ID_STRING
 };
 
-int csmp_get_tlvindex(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_tlvindex(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
-  int i = 0;
-  int j = 0;
   size_t rv = 0;
 
   DPRINTF("csmpagent_tlvindex: start working.\n");

--- a/src/csmpagent/csmp_uptime.c
+++ b/src/csmpagent/csmp_uptime.c
@@ -20,9 +20,9 @@
 #include "csmptlv.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_uptime(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_uptime(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
-  struct timeval tv = {0};
+  // struct timeval tv = {0};
   size_t rv = 0;
   uint32_t num;
 

--- a/src/csmpagent/csmp_wpanStatus.c
+++ b/src/csmpagent/csmp_wpanStatus.c
@@ -20,7 +20,7 @@
 #include "csmpagent.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_wpanStatus(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
+int csmp_get_wpanStatus(tlvid_t tlvid, uint8_t *buf, size_t len)
 {
   size_t rv = 0;
   uint32_t i, num;

--- a/src/csmpagent/csmpagent.c
+++ b/src/csmpagent/csmpagent.c
@@ -18,7 +18,7 @@
 #include "csmpagent.h"
 #include "csmpfunction.h"
 
-int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex, uint32_t t1, uint32_t t2, struct sockaddr_in6 *from)
+int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   switch (tlvid.type) {
     case TLV_INDEX_TLVID:
@@ -78,7 +78,7 @@ int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex, uin
   }
 }
 
-int csmpagent_post(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex, struct sockaddr_in6 *from)
+int csmpagent_post(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   switch (tlvid.type) {
     case CURRENT_TIME_TLVID:

--- a/src/csmpagent/csmpagent.h
+++ b/src/csmpagent/csmpagent.h
@@ -35,12 +35,9 @@
  * @param buf  request buffer
  * @param len  request buffer length
  * @param tlvindex   tlv url that is used
- * @param t1
- * @param t2
- * @param from  callee address
  * @return int 0 is success
  */
-int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex, uint32_t t1, uint32_t t2, struct sockaddr_in6 *from);
+int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex);
 
 /**
  * @brief coap POST handler, based on tlvid as URL
@@ -52,30 +49,27 @@ int csmpagent_get(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex, uin
  * @param out_size response buffer size
  * @param out_len actual used length of the response buffer
  * @param tlvindex index
- * @param from callee address, also used for the response
  * @return int  0 is success
  */
-int csmpagent_post(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex, struct sockaddr_in6 *from);
+int csmpagent_post(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex);
 
 /**
  * @brief check signature
  *
  * @param buf request buffer
  * @param len request buffer size
- * @param srcaddr sender address
  * @return int 0 is success
  */
-int checkSignature(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcaddr);
+int checkSignature(const uint8_t *buf, uint32_t len);
 
 /**
  * @brief check group
  *
  * @param buf request buffer
  * @param len request buffer length
- * @param srcaddr sender address
  * @return true
  * @return false
  */
-bool checkGroup(const uint8_t *buf, uint32_t len, struct sockaddr_in6 *srcaddr);
+bool checkGroup(const uint8_t *buf, uint32_t len);
 
 #endif

--- a/src/csmptlv/ProtobufVarint.c
+++ b/src/csmptlv/ProtobufVarint.c
@@ -229,27 +229,27 @@ parse_sint64(int64_t *member, const uint8_t *data, uint32_t len)
   return rv;
 }
 
-uint32_t ProtobufVarint_encodeUINT32(uint8_t *buf, uint32_t len, uint32_t val) {
+uint32_t ProtobufVarint_encodeUINT32(uint8_t *buf, uint32_t val) {
   return uint32_pack(val, buf);
 }
 
-uint32_t ProtobufVarint_encodeINT32(uint8_t *buf, uint32_t len, int32_t val) {
+uint32_t ProtobufVarint_encodeINT32(uint8_t *buf, int32_t val) {
   return int32_pack(val,buf);
 }
 
-uint32_t ProtobufVarint_encodeSINT32(uint8_t *buf, uint32_t len, int32_t val) {
+uint32_t ProtobufVarint_encodeSINT32(uint8_t *buf, int32_t val) {
   return sint32_pack(val,buf);
 }
 
-uint32_t ProtobufVarint_encodeUINT64(uint8_t *buf, uint32_t len, uint64_t val) {
+uint32_t ProtobufVarint_encodeUINT64(uint8_t *buf, uint64_t val) {
   return uint64_pack(val, buf);
 }
 
-uint32_t ProtobufVarint_encodeINT64(uint8_t *buf, uint32_t len, int64_t val) {
+uint32_t ProtobufVarint_encodeINT64(uint8_t *buf, int64_t val) {
   return uint64_pack((uint64_t)val,buf);
 }
 
-uint32_t ProtobufVarint_encodeSINT64(uint8_t *buf, uint32_t len, int64_t val) {
+uint32_t ProtobufVarint_encodeSINT64(uint8_t *buf, int64_t val) {
   return sint64_pack(val,buf);
 }
 
@@ -258,7 +258,7 @@ uint32_t ProtobufVarint_decodeUINT32(const uint8_t *buf, uint32_t len, uint32_t 
 }
 
 uint32_t ProtobufVarint_decodeINT32(const uint8_t *buf, uint32_t len, int32_t *val) {
-  return parse_int32(val,buf,len);
+  return parse_int32((uint32_t *)val,buf,len);
 }
 
 uint32_t ProtobufVarint_decodeSINT32(const uint8_t *buf, uint32_t len, int32_t *val) {

--- a/src/lib/trickle_timer/trickle_timer.c
+++ b/src/lib/trickle_timer/trickle_timer.c
@@ -47,9 +47,9 @@ static int32_t m_remaining = (1UL << 31) - 1; /* max int32_t */
 static bool m_timert_isrunning = false;
 
 void update_timer();
-void alarm_fired(int32_t sig);
+void alarm_fired();
 
-void *timer_thread(void *arg) {
+void *timer_thread(void*) {
   sigset_t set;
 
   sigemptyset(&set);
@@ -68,7 +68,7 @@ void *timer_thread(void *arg) {
   }
 }
 
-void alarm_fired(int32_t sig)
+void alarm_fired(void)
 {
   uint32_t min;
   uint8_t i;
@@ -95,10 +95,12 @@ void alarm_fired(int32_t sig)
     if (timer->icur > timer->imax)
       timer->icur = timer->imax;
 
-    if(i == reg_timer)
+    if(i == reg_timer) {
       DPRINTF("register trickle timer fired\n");
-    else if(i == rpt_timer)
+    }
+    else if(i == rpt_timer) {
       DPRINTF("metrics report trickle timer fired\n");
+    }
 
     timer_fired[i]();
     min = timer->icur >> 1;
@@ -138,7 +140,6 @@ void trickle_timer_start(timerid_t timerid, uint32_t imin, uint32_t imax, trickl
   uint32_t min;
   struct timeval tv = {0};
   uint32_t seed = 0;
-  int rv;
   sigset_t set;
 
   if(!m_timert_isrunning) {
@@ -147,15 +148,17 @@ void trickle_timer_start(timerid_t timerid, uint32_t imin, uint32_t imax, trickl
     sigprocmask(SIG_BLOCK, &set, NULL);
 
     sem_init(&sem, 0, 0);
-    rv = pthread_create(&timert_id, NULL, timer_thread, NULL);
+    pthread_create(&timert_id, NULL, timer_thread, NULL);
     pthread_detach(timert_id);
     m_timert_isrunning = true;
   }
 
-  if(timerid == reg_timer)
+  if(timerid == reg_timer) {
     DPRINTF("register trickle timer start\n");
-  else if(timerid == rpt_timer)
+  }
+  else if(timerid == rpt_timer) {
     DPRINTF("metrics report trickle timer start\n");
+  }
 
   gettimeofday(&tv, NULL);
 
@@ -178,11 +181,12 @@ void trickle_timer_stop(timerid_t timerid)
   sigset_t set;
 
   timers[timerid].is_running = false;
-  if(timerid == reg_timer)
+  if(timerid == reg_timer) {
     DPRINTF("register trickle timer stop\n");
-  else if(timerid == rpt_timer)
+  }
+  else if(timerid == rpt_timer) {
     DPRINTF("metrics report trickle timer stop\n");
-
+  }
   for(i = 0; i < timer_num; i++) {
     if(timers[i].is_running)
       return;


### PR DESCRIPTION
Set compiler warnings to max -Wall -Wextra -Wno-missing-braces (the latter is to ignore warnings caused protoc generated code). Resolve integer comparison type mismatch warnings. 
Resolve unused parameter warnings.
Resolve unused variable warnings.
