### PR TITLE
Resolve unused argument warnings. Resolve missing prototype header fi…

### DIFF
--- a/src/csmpagent/csmp_currenttime.c
+++ b/src/csmpagent/csmp_currenttime.c
@@ -19,13 +19,15 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t num;
-
+  
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_currenttime: start working.\n");
   CurrentTime CurrentTimeMsg = CURRENT_TIME__INIT;
 
@@ -57,7 +59,7 @@ int csmp_get_currenttime(tlvid_t tlvid, uint8_t *buf, size_t len)
   }
 }
 
-int csmp_put_currenttime(tlvid_t tlvid, const uint8_t *buf, size_t len)
+int csmp_put_currenttime(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   CurrentTime *CurrentTimeMsg = NULL;
   Current_Time current_time = CURRENT_TIME_INIT;
@@ -66,6 +68,11 @@ int csmp_put_currenttime(tlvid_t tlvid, const uint8_t *buf, size_t len)
   const uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
+
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
 
   DPRINTF("Received POST currenttime TLV\n");
 

--- a/src/csmpagent/csmp_deviceid.c
+++ b/src/csmpagent/csmp_deviceid.c
@@ -19,13 +19,15 @@
 #include "csmp.h"
 #include "csmpinfo.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "csmptlv.h"
 #include "CsmpTlvs.pb-c.h"
 
 extern uint8_t g_csmplib_eui64[8];
 
-int csmp_get_deviceid(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_deviceid(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
+  (void)tlvindex; // Suppress unused param compiler warning.
   size_t rv = 0;
   char id[128];
   DeviceID DeviceIDMsg = DEVICE_ID__INIT;

--- a/src/csmpagent/csmp_firmwareImageInfo.c
+++ b/src/csmpagent/csmp_firmwareImageInfo.c
@@ -18,13 +18,15 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_firmwareImageInfo(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_firmwareImageInfo(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t num;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_firmwareImageInfo: start working.\n");
 
   FirmwareImageInfo FirmwareImageInfoMsg = FIRMWARE_IMAGE_INFO__INIT;

--- a/src/csmpagent/csmp_group.c
+++ b/src/csmpagent/csmp_group.c
@@ -19,6 +19,7 @@
 #include "csmp.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
 static uint32_t m_GroupIds[CSMP_GROUP_NUM_TYPES] = {0};
@@ -48,14 +49,15 @@ bool checkGroup(const uint8_t *buf, uint32_t len) {
   return true;
 }
 
-int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   GroupAssign GroupAssignMsg = GROUP_ASSIGN__INIT;
   uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
   int i;
-
+  
+  (void)tlvindex; // Suppress unused param compiler warning.
   DPRINTF("csmpagent_groupAssign: start working.\n");
   GroupAssignMsg.type_present_case = GROUP_ASSIGN__TYPE_PRESENT_TYPE;
   GroupAssignMsg.id_present_case = GROUP_ASSIGN__ID_PRESENT_ID;
@@ -79,7 +81,7 @@ int csmp_get_groupAssign(tlvid_t tlvid, uint8_t *buf, size_t len)
   return used;
 }
 
-int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len)
+int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   GroupAssign *GroupAssignMsg = NULL;
   tlvid_t tlvid0;
@@ -87,6 +89,12 @@ int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len)
   const uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
+
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
 
   DPRINTF("Received POST groupAssign TLV\n");
 
@@ -120,7 +128,7 @@ int csmp_put_groupAssign(tlvid_t tlvid, const uint8_t *buf, size_t len)
   return used;
 }
 
-int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len)
+int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   GroupMatch *GroupMatchMsg = NULL;
   tlvid_t tlvid0;
@@ -128,6 +136,12 @@ int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len)
   const uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
+
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
 
   DPRINTF("Received POST groupMatch TLV\n");
 
@@ -161,7 +175,7 @@ int csmp_put_groupMatch(tlvid_t tlvid, const uint8_t *buf, size_t len)
 
 }
 
-int csmp_get_groupInfo(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_groupInfo(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   GroupInfo GroupInfoMsg = GROUP_INFO__INIT;
   uint8_t *pbuf = buf;
@@ -169,6 +183,7 @@ int csmp_get_groupInfo(tlvid_t tlvid, uint8_t *buf, size_t len)
   int used = 0;
   int i;
 
+  (void)tlvindex; // Suppress unused param compiler warning.
   DPRINTF("csmpagent_groupInfo: start working.\n");
   GroupInfoMsg.type_present_case = GROUP_INFO__TYPE_PRESENT_TYPE;
   GroupInfoMsg.id_present_case = GROUP_INFO__ID_PRESENT_ID;

--- a/src/csmpagent/csmp_hardwareDesc.c
+++ b/src/csmpagent/csmp_hardwareDesc.c
@@ -18,12 +18,15 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_hardwareDesc(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_hardwareDesc(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t num;
+  
+  (void)tlvindex; // Suppress un-used param warning.
 
   DPRINTF("csmpagent_hardwareDesc: start working.\n");
 

--- a/src/csmpagent/csmp_interfaceDesc.c
+++ b/src/csmpagent/csmp_interfaceDesc.c
@@ -18,17 +18,18 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_interfaceDesc(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_interfaceDesc(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_interfaceDesc: start working.\n");
-
 
   Interface_Desc *interface_desc = NULL;
   interface_desc = g_csmptlvs_get(tlvid, &num);

--- a/src/csmpagent/csmp_interfaceMetrics.c
+++ b/src/csmpagent/csmp_interfaceMetrics.c
@@ -19,15 +19,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_interfaceMetrics(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_interfaceMetrics(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_interfaceMetrics: start working.\n");
 
   Interface_Metrics *interface_metrics = NULL;

--- a/src/csmpagent/csmp_ipAddress.c
+++ b/src/csmpagent/csmp_ipAddress.c
@@ -18,15 +18,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipAddress(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_ipAddress(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_ipAddress: start working.\n");
 
 

--- a/src/csmpagent/csmp_ipRoute.c
+++ b/src/csmpagent/csmp_ipRoute.c
@@ -18,15 +18,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipRoute(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_ipRoute(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_ipRoute: start working.\n");
 
 

--- a/src/csmpagent/csmp_ipRouteRplMetrics.c
+++ b/src/csmpagent/csmp_ipRouteRplMetrics.c
@@ -19,15 +19,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_ipRouteRplMetrics(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_ipRouteRplMetrics(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_ipRouteRplMetrics: start working.\n");
   IPRouteRPLMetrics IPRouteRPLMetricsMsg = IPROUTE_RPLMETRICS__INIT;
 

--- a/src/csmpagent/csmp_reportSubscribe.c
+++ b/src/csmpagent/csmp_reportSubscribe.c
@@ -20,6 +20,7 @@
 #include "cgmsagent.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
 #define MAX_CNT 15
@@ -27,7 +28,7 @@
 
 csmp_subscription_list_t g_csmplib_report_list;
 
-int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   ReportSubscribe ReportSubscribeMsg = REPORT_SUBSCRIBE__INIT;
   uint32_t i;
@@ -35,6 +36,8 @@ int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len)
   size_t rv, used = 0;
   char **tlvlist = NULL;
 
+  (void)tlvindex; // Suppress unused param compiler warning.
+  
   tlvlist = malloc(MAX_CNT * sizeof(void *));
 
   DPRINTF("csmpagent_reportSubscribe: start working.\n");
@@ -65,7 +68,7 @@ int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len)
   return used;
 }
 
-int csmp_put_reportSubscribe(const uint8_t *buf, size_t len)
+int csmp_put_reportSubscribe(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   ReportSubscribe *ReportSubscribeMsg = NULL;
   tlvid_t tlvid0;
@@ -75,6 +78,12 @@ int csmp_put_reportSubscribe(const uint8_t *buf, size_t len)
   size_t rv;
   int used = 0;
   long unsigned int i;
+
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
 
   DPRINTF("Received POST reportSubscribe TLV\n");
 

--- a/src/csmpagent/csmp_rplInstance.c
+++ b/src/csmpagent/csmp_rplInstance.c
@@ -18,15 +18,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_rplInstance(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_rplInstance(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused arg warning.
   DPRINTF("csmpagent_rplInstance: start working.\n");
 
 

--- a/src/csmpagent/csmp_sessionId.c
+++ b/src/csmpagent/csmp_sessionId.c
@@ -18,13 +18,15 @@
 #include "csmp.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
 static SessionID gSessionIDVal = SESSION_ID__INIT;
 static char sessionID[17] = {0};
 
-int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
+  (void)tlvindex; // Suppress unused param compiler warning.
   size_t rv = 0;
 
   DPRINTF("csmpagent_sessionID: start working.\n");
@@ -42,7 +44,7 @@ int csmp_get_sessionID(tlvid_t tlvid, uint8_t *buf, size_t len)
   }
 }
 
-int csmp_put_sessionID(const uint8_t *buf, size_t len)
+int csmp_put_sessionID(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   SessionID *SessionIDMsg = NULL;
   tlvid_t tlvid0;
@@ -50,6 +52,12 @@ int csmp_put_sessionID(const uint8_t *buf, size_t len)
   const uint8_t *pbuf = buf;
   size_t rv;
   int used = 0;
+  
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
 
   DPRINTF("Received POST sessionID TLV\n");
 

--- a/src/csmpagent/csmp_signature.c
+++ b/src/csmpagent/csmp_signature.c
@@ -19,6 +19,7 @@
 #include "csmp.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
 static Signature g_SigMsg = SIGNATURE__INIT;
@@ -118,7 +119,7 @@ int checkSignature(const uint8_t *buf, uint32_t len) {
 #endif
 }
 
-int csmp_put_signature(const uint8_t *buf, size_t len)
+int csmp_put_signature(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   Signature *SignatureMsg = NULL;
   tlvid_t tlvid0;
@@ -127,6 +128,11 @@ int csmp_put_signature(const uint8_t *buf, size_t len)
   size_t rv;
   int used = 0;
 
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
   DPRINTF("Received POST Signature TLV\n");
 
   rv = csmptlv_readTL(pbuf, len, &tlvid0, &tlvlen);
@@ -152,7 +158,7 @@ int csmp_put_signature(const uint8_t *buf, size_t len)
   return used;
 }
 
-int csmp_put_signatureValidity(const uint8_t *buf, size_t len)
+int csmp_put_signatureValidity(tlvid_t tlvid, const uint8_t *buf, size_t len, uint8_t *out_buf, size_t out_size, size_t *out_len, int32_t tlvindex)
 {
   SignatureValidity *SignatureValidityMsg = NULL;
   tlvid_t tlvid0;
@@ -161,6 +167,11 @@ int csmp_put_signatureValidity(const uint8_t *buf, size_t len)
   size_t rv;
   int used = 0;
 
+  (void) tlvid; // Suppress unused param compiler warning.
+  (void) out_buf; // Suppress unused param compiler warning.
+  (void) out_size; // Suppress unused param compiler warning.
+  (void) out_len; // Suppress unused param compiler warning.
+  (void) tlvindex; // Suppress unused param compiler warning.
   DPRINTF("Received POST SignatureValidity TLV\n");
 
   rv = csmptlv_readTL(pbuf, len, &tlvid0, &tlvlen);

--- a/src/csmpagent/csmp_tlvindex.c
+++ b/src/csmpagent/csmp_tlvindex.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include "csmp.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "csmptlv.h"
 #include "CsmpTlvs.pb-c.h"
 
@@ -43,8 +44,9 @@ static char *ptlvs[NUM_TLVS] = {
   FIRMWARE_IMAGE_INFO_ID_STRING
 };
 
-int csmp_get_tlvindex(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_tlvindex(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
+  (void)tlvindex; // Suppress unused param compiler warning.
   size_t rv = 0;
 
   DPRINTF("csmpagent_tlvindex: start working.\n");

--- a/src/csmpagent/csmp_uptime.c
+++ b/src/csmpagent/csmp_uptime.c
@@ -17,15 +17,17 @@
 #include "csmp.h"
 #include "csmpinfo.h"
 #include "csmpservice.h"
+#include "csmpfunction.h"
 #include "csmptlv.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_uptime(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_uptime(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   // struct timeval tv = {0};
   size_t rv = 0;
   uint32_t num;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_uptime: start working.\n");
   Uptime UptimeMsg = UPTIME__INIT;
 

--- a/src/csmpagent/csmp_wpanStatus.c
+++ b/src/csmpagent/csmp_wpanStatus.c
@@ -18,15 +18,17 @@
 #include "csmpinfo.h"
 #include "csmptlv.h"
 #include "csmpagent.h"
+#include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
 
-int csmp_get_wpanStatus(tlvid_t tlvid, uint8_t *buf, size_t len)
+int csmp_get_wpanStatus(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tlvindex)
 {
   size_t rv = 0;
   uint32_t i, num;
   uint8_t *pbuf = buf;
   uint32_t used = 0;
 
+  (void)tlvindex; // Suppress unused param warning.
   DPRINTF("csmpagent_wpanStatus: start working.\n");
 
 


### PR DESCRIPTION
Renesas reported that build was throwing hundreds of compiler warnings when compiled within their environment.  Function prototype includes were also missing.  This PR resolves the issues.  Build is clean and operates correctly with an instance of FND.