### PR TITLE
Add allocator API to OSAL

### DIFF
--- a/osal/freertos/osal_common.c
+++ b/osal/freertos/osal_common.c
@@ -156,3 +156,23 @@ int osal_sigaddset(sigset_t *set, int signum)
 {
     /* FreeRtos implementation */
 }
+
+void *osal_malloc(size_t size)
+{
+    /* FreeRtos implementation */
+}
+
+void *osal_calloc(size_t num, size_t size)
+{
+    /* FreeRtos implementation */
+}
+
+void *osal_realloc(void *ptr, size_t size)
+{
+    /* FreeRtos implementation */
+}
+
+void osal_free(void *ptr)
+{
+    /* FreeRtos implementation */
+}

--- a/osal/freertos/osal_common.h
+++ b/osal/freertos/osal_common.h
@@ -84,4 +84,10 @@ osal_sighandler_t osal_signal(int signum, osal_sighandler_t handler);
 int osal_sigprocmask(int how, const sigset_t *set, sigset_t *oldset);
 int osal_sigemptyset(sigset_t *set);
 int osal_sigaddset(sigset_t *set, int signum);
+
+void *osal_malloc(size_t size);
+void *osal_calloc(size_t num, size_t size);
+void *osal_realloc(void *ptr, size_t size);
+void osal_free(void *ptr); 
+
 #endif

--- a/osal/linux/osal_common.c
+++ b/osal/linux/osal_common.c
@@ -715,3 +715,23 @@ void osal_trickle_timer_stop(timerid_t timerid)
   osal_task_sigmask(SIG_UNBLOCK, &set, NULL);
   m_timert_isrunning = false;
 }
+
+void *osal_malloc(size_t size)
+{
+  return malloc(size);
+}
+
+void *osal_calloc(size_t num, size_t size)
+{
+  return calloc(num, size);
+}
+
+void *osal_realloc(void *ptr, size_t size)
+{
+  return realloc(ptr, size);
+}
+
+void osal_free(void *ptr)
+{
+  free(ptr);
+}

--- a/osal/linux/osal_common.h
+++ b/osal/linux/osal_common.h
@@ -102,4 +102,9 @@ typedef void (*trickle_timer_fired_t) ();
 void osal_trickle_timer_start(timerid_t timerid, uint32_t imin, uint32_t imax, trickle_timer_fired_t trickle_time_fired);
 void osal_trickle_timer_stop(timerid_t timerid);
 
+void *osal_malloc(size_t size);
+void *osal_calloc(size_t num, size_t size);
+void *osal_realloc(void *ptr, size_t size);
+void osal_free(void *ptr); 
+
 #endif

--- a/sample/signature_verify.c
+++ b/sample/signature_verify.c
@@ -18,7 +18,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
+#include "osal_common.h"
 
 #ifdef OPENSSL
 #include <openssl/evp.h>
@@ -40,7 +40,7 @@ bool signature_verify(const void *data, size_t datalen, const void *sig, size_t 
   int ret;
   EC_KEY *ec_key = NULL;
   EC_GROUP *ec_group;
-  char *pp = (char *)malloc(sizeof(char) * PUBLIC_KEY_LEN+1);
+  char *pp = (char *)osal_malloc(sizeof(char) * PUBLIC_KEY_LEN+1);
   char *pp_o2i = pp;
   pubkey_get(pp);
   EVP_MD_CTX *md_ctx;
@@ -99,7 +99,7 @@ bool signature_verify(const void *data, size_t datalen, const void *sig, size_t 
   EC_KEY_free(ec_key);
   ECDSA_SIG_free(si);
 
-  free(pp);
+  osal_free(pp);
   if(ret==1)
   {
     printf("Signature Verify：OK\n");

--- a/src/csmpagent/csmp_reportSubscribe.c
+++ b/src/csmpagent/csmp_reportSubscribe.c
@@ -14,7 +14,6 @@
  *  limitations under the License.
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include "csmp.h"
 #include "cgmsagent.h"
@@ -22,6 +21,7 @@
 #include "csmpagent.h"
 #include "csmpfunction.h"
 #include "CsmpTlvs.pb-c.h"
+#include "osal_common.h"
 
 #define MAX_CNT 15
 #define MAX_LEN 8
@@ -38,14 +38,14 @@ int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tl
 
   (void)tlvindex; // Suppress unused param compiler warning.
   
-  tlvlist = malloc(MAX_CNT * sizeof(void *));
+  tlvlist = osal_malloc(MAX_CNT * sizeof(void *));
 
   DPRINTF("csmpagent_reportSubscribe: start working.\n");
   ReportSubscribeMsg.interval_present_case = REPORT_SUBSCRIBE__INTERVAL_PRESENT_INTERVAL;
   ReportSubscribeMsg.interval = g_csmplib_report_list.period;
 
   for (i = 0;i < g_csmplib_report_list.cnt;i++) {
-    tlvlist[i] = malloc(MAX_LEN);
+    tlvlist[i] = osal_malloc(MAX_LEN);
     csmptlv_id2str(tlvlist[i],MAX_LEN,&g_csmplib_report_list.list[i]);
   }
   ReportSubscribeMsg.n_tlvid = g_csmplib_report_list.cnt;
@@ -62,8 +62,8 @@ int csmp_get_reportSubscribe(tlvid_t tlvid, uint8_t *buf, size_t len, int32_t tl
   pbuf += rv; used += rv;
 
   for (i = 0;i < g_csmplib_report_list.cnt;i++)
-    free(tlvlist[i]);
-  free(tlvlist);
+    osal_free(tlvlist[i]);
+  osal_free(tlvlist);
 
   return used;
 }

--- a/src/lib/protobuf-c/protobuf-c.c
+++ b/src/lib/protobuf-c/protobuf-c.c
@@ -45,8 +45,8 @@
  * \todo Use size_t consistently.
  */
 
-#include <stdlib.h>	/* for malloc, free */
 #include <string.h>	/* for strcmp, strlen, memcpy, memmove, memset */
+#include "osal_common.h"	/* for malloc, free */
 
 #include "protobuf-c.h"
 
@@ -151,14 +151,14 @@ static void *
 system_alloc(void *allocator_data, size_t size)
 {
 	(void)allocator_data;
-	return malloc(size);
+	return osal_malloc(size);
 }
 
 static void
 system_free(void *allocator_data, void *data)
 {
 	(void)allocator_data;
-	free(data);
+	osal_free(data);
 }
 
 static inline void *

--- a/src/lib/protobuf-c/protobuf-c.h
+++ b/src/lib/protobuf-c/protobuf-c.h
@@ -200,6 +200,7 @@ size_t foo__bar__baz_bah__pack_to_buffer
 #include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
+#include "osal_common.h"
 
 #ifdef __cplusplus
 # define PROTOBUF_C__BEGIN_DECLS	extern "C" {
@@ -1065,7 +1066,7 @@ do {                                                                    \
 				(simp_buf)->allocator,                  \
 				(simp_buf)->data);			\
 		else                                                    \
-			free((simp_buf)->data);                         \
+			osal_free((simp_buf)->data);                         \
 	}                                                               \
 } while (0)
 


### PR DESCRIPTION
Add possibility to port dynamic memory allocator functions (stdlib malloc, calloc, realloc, free). With osal allocator functions, thread-safe and advanced solutions can be ported, supporting other platforms that don't use stdlib or they have other dynamic memory management implementation.