### PR TITLE
Fix Renesas CC-RX compiler warnings

### DIFF
--- a/src/csmpagent/csmp_firmwareMgmt.c
+++ b/src/csmpagent/csmp_firmwareMgmt.c
@@ -49,7 +49,7 @@ int csmp_get_transferRequest(tlvid_t tlvid, uint8_t *buf, size_t len,
 
     if(xfer_req) {
         // Firmware status check
-        if (!xfer_req->has_status || xfer_req->status != FWHDR_STATUS_DOWNLOAD) {
+        if (!xfer_req->has_status || xfer_req->status != (uint32_t) FWHDR_STATUS_DOWNLOAD) {
           DPRINTF("csmpagent_firmwaremgmt: Transfer request status error! (%x)\n", 
                   xfer_req->status);  
           return CSMP_OP_TLV_RD_EMPTY;

--- a/src/csmpapi/csmpservice.c
+++ b/src/csmpapi/csmpservice.c
@@ -22,7 +22,7 @@
 #include "cgmsagent.h"
 #include "csmpserver.h"
 
-uint8_t g_csmplib_status = SERVICE_NOT_START;
+csmp_service_status_t g_csmplib_status = SERVICE_NOT_START;
 
 uint8_t g_csmplib_eui64[8];
 uint32_t g_csmplib_reginterval_min = 0;

--- a/src/csmpservice/cgmsagent.c
+++ b/src/csmpservice/cgmsagent.c
@@ -42,7 +42,7 @@ enum {
   REASON_OUTAGE_RECOVERY = 8
 };
 
-extern uint8_t g_csmplib_status;
+extern csmp_service_status_t g_csmplib_status;
 extern uint32_t g_csmplib_reginterval_min;
 extern uint32_t g_csmplib_reginterval_max;
 extern csmp_subscription_list_t g_csmplib_report_list;
@@ -286,6 +286,8 @@ void response_handler(struct sockaddr_in6 *from, uint16_t status, const void *bo
       g_csmplib_stats.reg_fails++;
       g_csmplib_stats.reg_fails_stats.error_process++;
     }
+    break;
+  default:
     break;
   }
   return;

--- a/src/lib/protobuf-c/protobuf-c.c
+++ b/src/lib/protobuf-c/protobuf-c.c
@@ -2892,7 +2892,7 @@ parse_member(ScannedMember *scanned_member,
 			message->unknown_fields +
 			(message->n_unknown_fields++);
 		ufield->tag = scanned_member->tag;
-		ufield->wire_type = scanned_member->wire_type;
+		ufield->wire_type = (ProtobufCWireType) scanned_member->wire_type;
 		ufield->len = scanned_member->len;
 		ufield->data = do_alloc(allocator, scanned_member->len);
 		if (ufield->data == NULL)


### PR DESCRIPTION
## Summary

This PR fixes several compiler warnings reported by the Renesas CC-RX compiler.

The changes address warnings related to:

- enum/integer type mixing
- signedness-changing integer conversions
- missing handling of enum values in a switch statement

## Changes

- Use `csmp_service_status_t` instead of `uint8_t` for `g_csmplib_status`.
- Add an explicit `default` case in `response_handler()`.
- Add explicit casts where CC-RX warns about enum/integer conversions.

## Motivation

The Renesas CC-RX compiler performs stricter checks for enum and integer conversions than some other compilers. These warnings make the build noisy and may break builds where warnings are treated as errors.

## Related issue

Fixes #44 