### PR TITLE
Add OSAL abstraction for closing sockets

### DIFF
--- a/osal/efr32_wisun/osal_efr32_wisun.c
+++ b/osal/efr32_wisun/osal_efr32_wisun.c
@@ -188,6 +188,11 @@ osal_socket_handle_t osal_socket(osal_basetype_t domain,
     return socket(domain, type, protocol);
 }
 
+osal_basetype_t osal_socket_close(osal_socket_handle_t sockd)
+{
+     return close(sockd);
+}
+
 osal_ssize_t osal_recvfrom(osal_socket_handle_t sockd, void *buf, size_t len, osal_basetype_t flags,
                            osal_sockaddr_t *src_addr, osal_socklen_t *addrlen)
 {

--- a/osal/freertos/osal_freertos.c
+++ b/osal/freertos/osal_freertos.c
@@ -151,6 +151,11 @@ osal_socket_handle_t osal_socket(osal_basetype_t domain, osal_basetype_t type, o
     return socket(domain, type, protocol);
 }
 
+osal_basetype_t osal_socket_close(osal_socket_handle_t sockd)
+{
+     return close(sockd);
+}
+
 osal_ssize_t osal_recvfrom(osal_socket_handle_t sockd, void *buf, size_t len, osal_basetype_t flags,
                            osal_sockaddr_t *src_addr, osal_socklen_t *addrlen)
 {

--- a/osal/linux/osal_linux.c
+++ b/osal/linux/osal_linux.c
@@ -118,6 +118,11 @@ osal_socket_handle_t osal_socket(osal_basetype_t domain, osal_basetype_t type, o
     return(socket(domain, type, protocol));
 }
 
+osal_basetype_t osal_socket_close(osal_socket_handle_t sockd)
+{
+     return close(sockd);
+}
+
 osal_basetype_t osal_bind(osal_socket_handle_t sockd, osal_sockaddr_t *addr, osal_socklen_t addrlen)
 {
     return (bind(sockd, (const struct sockaddr *)(addr), addrlen));

--- a/osal/osal.h
+++ b/osal/osal.h
@@ -247,9 +247,22 @@ osal_basetype_t osal_sem_destroy(osal_sem_t *sem);
  * @param[in] protocol specifies a particular protocol to be used with the socket
  *
  * output parameters
- * @return 0 on success; on error, -1 is returned
+ * @return socket descriptor on success; on error, -1 is returned
  *****************************************************************************/
 osal_socket_handle_t osal_socket(osal_basetype_t domain, osal_basetype_t type, osal_basetype_t protocol);
+
+/****************************************************************************
+ * @fn osal_socket_close
+ *
+ * @brief close a communication endpoint.
+ *
+ * input parameters
+ * @param[in] sockd socket descriptor
+ *
+ * output parameters
+ * @return 0 on success; on error, -1 is returned
+ *****************************************************************************/
+osal_basetype_t osal_socket_close(osal_socket_handle_t sockd);
 
 /****************************************************************************
  * @fn osal_recvfrom

--- a/src/coap/coapclient.c
+++ b/src/coap/coapclient.c
@@ -46,7 +46,7 @@ int coapclient_stop()
 {
   m_client_opened = false;
   osal_task_cancel(recvt_id_task);
-  return close(m_sock);
+  return osal_socket_close(m_sock);
 }
 
 int coapclient_open(response_handler_t response_handler)

--- a/src/coap/coapserver.c
+++ b/src/coap/coapserver.c
@@ -46,7 +46,7 @@ int coapserver_stop()
 {
   m_server_opened = false;
   osal_task_cancel(recvt_id_task);
-  return close(m_sockfd);
+  return osal_socket_close(m_sockfd);
 }
 
 int coapserver_listen(uint16_t sport, recv_handler_t recv_handler)
@@ -77,7 +77,7 @@ int coapserver_listen(uint16_t sport, recv_handler_t recv_handler)
   osal_update_sockaddr(&listen_addr, sport);
   if (osal_bind(sockfd, &listen_addr, sizeof(listen_addr)) < 0) {
     DPRINTF("coapserver_listen bind error!\n");
-    close(sockfd);
+    osal_socket_close(sockfd);
     return -1;
   }
 


### PR DESCRIPTION
## Summary

This PR extends the OSAL socket interface with a wrapper for closing sockets.

The OSAL already provides `osal_socket()` for opening sockets. This PR adds the corresponding `osal_socket_close()` function and uses it in the CoAP client/server code instead of calling `close()` directly.

## Changes

- Add `osal_socket_close()` declaration to `osal/osal.h`.
- Implement `osal_socket_close()` for:
  - Linux
  - FreeRTOS
  - EFR32 Wi-SUN
- Replace direct `close()` calls in:
  - `src/coap/coapclient.c`
  - `src/coap/coapserver.c`
- Correct the documentation of `osal_socket()` to state that it returns a socket descriptor on success.

## Motivation

Socket creation is already abstracted through OSAL via `osal_socket()`, but socket cleanup was still performed directly with `close()`.

Adding `osal_socket_close()` makes the socket lifecycle consistently platform-independent:

```c
osal_socket(...)
osal_socket_close(...)
```

This improves portability and keeps platform-specific socket handling inside the OSAL backend implementations.

## Related issue

Fixes #47 