### PR TITLE
Move firmware management config to platform types

### DIFF
--- a/osal/efr32_wisun/osal_platform_types.h
+++ b/osal/efr32_wisun/osal_platform_types.h
@@ -56,4 +56,9 @@ typedef int osal_sd_set_t;
 #define GECKO_BTL_UPLOAD_SLOT_ID 0
 #define GECKO_BTL_BACKUP_SLOT_ID 1
 
+// Firmware Management Configuration
+#define CSMP_FWMGMT_ACTIVE_SLOTS      3          // 0-RUN, 1-UPLOAD, 2-BACKUP
+#define CSMP_FWMGMT_SLOTIMG_SIZE      (512*1024) // 512 Kb
+#define CSMP_FWMGMT_BLKMAP_CNT        (32)
+
 #endif

--- a/osal/freertos/osal_platform_types.h
+++ b/osal/freertos/osal_platform_types.h
@@ -54,4 +54,9 @@ typedef fd_set osal_sd_set_t;
 #define OSAL_AF_INET6 AF_INET6
 #define OSAL_SOCK_DGRAM SOCK_DGRAM
 
+// Firmware Management Configuration
+#define CSMP_FWMGMT_ACTIVE_SLOTS      3          // 0-RUN, 1-UPLOAD, 2-BACKUP
+#define CSMP_FWMGMT_SLOTIMG_SIZE      (30*1024)  // 30 Kb
+#define CSMP_FWMGMT_BLKMAP_CNT        (32)
+
 #endif

--- a/osal/linux/osal_platform_types.h
+++ b/osal/linux/osal_platform_types.h
@@ -55,6 +55,9 @@ typedef fd_set osal_sd_set_t;
 #define OSAL_AF_INET6 AF_INET6 
 #define OSAL_SOCK_DGRAM SOCK_DGRAM
 
-
+// Firmware Management Configuration
+#define CSMP_FWMGMT_ACTIVE_SLOTS      3          // 0-RUN, 1-UPLOAD, 2-BACKUP
+#define CSMP_FWMGMT_SLOTIMG_SIZE      (30*1024)  // 30 Kb
+#define CSMP_FWMGMT_BLKMAP_CNT        (32)
 
 #endif

--- a/osal/osal.h
+++ b/osal/osal.h
@@ -35,15 +35,6 @@
 #define HWID_SIZE             32
 #define BLOCK_SIZE            1024
 
-// IMAGE SLOT INFO
-#define CSMP_FWMGMT_ACTIVE_SLOTS      3          // 0-RUN, 1-UPLOAD, 2-BACKUP
-#if defined(OSAL_EFR32_WISUN)
-#define CSMP_FWMGMT_SLOTIMG_SIZE      (512*1024) // 512 Kb
-#else
-#define CSMP_FWMGMT_SLOTIMG_SIZE      (30*1024)  // 30 Kb
-#endif
-#define CSMP_FWMGMT_BLKMAP_CNT        (32)
-
 #define CSMP_IMAGE_HDR_SIZE           256
 
 #define REBOOT_DELAY 5


### PR DESCRIPTION
## Summary

This PR moves firmware management configuration values from the generic `osal/osal.h` header to the platform-specific `osal_platform_types.h` headers.

## Changes

- Remove firmware management slot configuration from `osal/osal.h`.
- Add the configuration to:
  - `osal/efr32_wisun/osal_platform_types.h`
  - `osal/freertos/osal_platform_types.h`
  - `osal/linux/osal_platform_types.h`
- Preserve the existing platform-specific slot image sizes:
  - EFR32 Wi-SUN: `512 * 1024`
  - FreeRTOS: `30 * 1024`
  - Linux: `30 * 1024`

## Motivation

The firmware management slot configuration is platform-dependent. Keeping these values in the generic OSAL header requires platform-specific conditional logic in `osal.h`.

Moving the configuration to the platform-specific OSAL type headers keeps the generic OSAL interface cleaner and places platform-dependent values closer to the corresponding platform implementation.

## Expected behavior

This is a refactoring change. The effective configuration values are preserved, so runtime behavior should remain unchanged.

## Related issue

Fixes #51 