### PR TITLE
Expose CoAP processing functions

### DIFF
--- a/src/coap/coapclient.c
+++ b/src/coap/coapclient.c
@@ -39,7 +39,6 @@ static void recv_fn(void*);
 #endif
 int write_option( uint8_t *buf, uint16_t buf_len, coap_option_t this_option, coap_option_t *last_option,
     const uint8_t* option_buf, uint32_t option_len, uint32_t *written_len );
-void process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from);
 void coap_option_map(uint32_t val, uint8_t *map);
 
 int coapclient_stop()
@@ -264,14 +263,14 @@ static void recv_fn(void* arg)
     DPRINTF("coapclient.Socket.recvfrom - Got %u-byte response from ",len);
     osal_print_formatted_ip(&from);
 
-    process_response(data, len, &from ); 
+    coapclient_process_response(data, len, &from );
  }
 #if defined(OSAL_LINUX)
   return NULL;
 #endif
 }
 
-void process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from)
+void coapclient_process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from)
 {
   uint8_t* cur = data;
   coap_header_t *hdr;

--- a/src/coap/coapclient.h
+++ b/src/coap/coapclient.h
@@ -78,4 +78,12 @@ int coapclient_request(const osal_sockaddr_t *to,
 		const coap_uri_seg_t *query, uint32_t query_cnt,
 		const void *body, uint16_t body_len);
 
+/**
+ * @brief process a response for the CoAP client
+ *
+ * @param data response data
+ * @param len response data length
+ * @param from response sender
+ */
+void coapclient_process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from);
 #endif

--- a/src/coap/coapserver.c
+++ b/src/coap/coapserver.c
@@ -33,7 +33,6 @@ static osal_basetype_t m_sockfd = 0;
 static bool m_server_opened = false;
 static recv_handler_t m_recv_handler = NULL;
 
-void process_datagram(void *data, uint16_t len, struct sockaddr_in6 *from );
 void send_internal_response(const struct sockaddr_in6 *from, uint16_t tx_id,
                             uint8_t token_length, uint8_t *token, uint16_t status);
 #if defined(OSAL_LINUX)
@@ -129,7 +128,7 @@ static void recv_thread(void* arg)
         ((uint16_t)from.sin6_addr.s6_addr[14] << 8) | from.sin6_addr.s6_addr[15],
         from.sin6_scope_id, ntohs(from.sin6_port));
 
-    process_datagram(data, len, &from );
+    coapserver_process_datagram(data, len, &from );
   }
 #if defined(OSAL_LINUX)
   return NULL;
@@ -207,7 +206,7 @@ int coapserver_response(const struct sockaddr_in6 *to,
   return 0;
 }
 
-void process_datagram(void *data, uint16_t len, struct sockaddr_in6 *from )
+void coapserver_process_datagram(uint8_t* data, uint16_t len, struct sockaddr_in6 *from )
 {
   uint8_t* cur = data;
   uint16_t buf_used = 0;

--- a/src/coap/coapserver.h
+++ b/src/coap/coapserver.h
@@ -105,4 +105,12 @@ int coapserver_response(const struct sockaddr_in6 *to,
     uint16_t status,
     const void* body, uint16_t body_len);
 
+/**
+ * @brief process a datagram for the CoAP server
+ *
+ * @param data datagram data
+ * @param len datagram data length
+ * @param from datagram sender
+ */
+void coapserver_process_datagram(uint8_t* data, uint16_t len, struct sockaddr_in6 *from);
 #endif


### PR DESCRIPTION
## Summary

This PR renames and exposes the CoAP client/server processing functions.

The generic internal function names are replaced with module-specific names and declarations are added to the corresponding CoAP headers.

## Changes

- Rename `process_response()` to `coapclient_process_response()`.
- Rename `process_datagram()` to `coapserver_process_datagram()`.
- Update the internal client/server receive loops to call the renamed functions.
- Add declarations and documentation comments to:
  - `src/coap/coapclient.h`
  - `src/coap/coapserver.h`

## Motivation

The previous function names were generic and not clearly associated with the CoAP client or server module.

Using module-specific names makes the global symbols clearer and avoids ambiguity. Exposing the functions in the headers also allows other code, such as tests or platform-specific integration code, to reuse the existing CoAP response/datagram processing logic.

## Expected behavior

This change should not alter runtime behavior.

The same processing logic is used as before, but the functions are now named more explicitly and declared in the corresponding public headers.

## Related issue

Fixes #55 