### PR TITLE
Add option to use external receive tasks

### DIFF
--- a/src/coap/coapclient.c
+++ b/src/coap/coapclient.c
@@ -31,12 +31,18 @@ static response_handler_t m_response_handler = NULL;
 static osal_basetype_t m_sock = 0;
 static bool m_client_opened = false;
 static uint16_t m_transaction_id = 0;
+#ifndef USE_EXTERNAL_RECV_TASKS
 static osal_task_t recvt_id_task;
+#endif
+
+#ifndef USE_EXTERNAL_RECV_TASKS
 #if defined(OSAL_LINUX)
 static void *recv_fn(void*);
 #else
 static void recv_fn(void*);
 #endif
+#endif
+
 int write_option( uint8_t *buf, uint16_t buf_len, coap_option_t this_option, coap_option_t *last_option,
     const uint8_t* option_buf, uint32_t option_len, uint32_t *written_len );
 void coap_option_map(uint32_t val, uint8_t *map);
@@ -44,14 +50,18 @@ void coap_option_map(uint32_t val, uint8_t *map);
 int coapclient_stop()
 {
   m_client_opened = false;
+#ifndef USE_EXTERNAL_RECV_TASKS
   osal_task_cancel(recvt_id_task);
+#endif
   return osal_socket_close(m_sock);
 }
 
 int coapclient_open(response_handler_t response_handler)
 {
   osal_socket_handle_t sockfd;
+#ifndef USE_EXTERNAL_RECV_TASKS
   osal_basetype_t ret = OSAL_FAILURE;
+#endif
 
   if (m_client_opened) {
     DPRINTF("coaplient was already opened!\n");
@@ -71,9 +81,11 @@ int coapclient_open(response_handler_t response_handler)
 
   m_sock = sockfd;
   m_client_opened = true;
+#ifndef USE_EXTERNAL_RECV_TASKS
   ret = osal_task_create(&recvt_id_task, NULL, 0, 0, recv_fn, NULL);
   DPRINTF("CoapClient.open - %s.\n" , (ret == OSAL_SUCCESS) ? "task created" : "task creation failed");
   assert(ret == OSAL_SUCCESS);
+#endif
   
   return 0;
 }
@@ -235,6 +247,8 @@ void coap_option_map(uint32_t val, uint8_t *map)
   else if (val <= 0xffff + 269)
     *map = 14;
 }
+
+#ifndef USE_EXTERNAL_RECV_TASKS
 #if defined(OSAL_LINUX)
 static void *recv_fn(void* arg)
 #else
@@ -269,6 +283,7 @@ static void recv_fn(void* arg)
   return NULL;
 #endif
 }
+#endif
 
 void coapclient_process_response(uint8_t* data, uint16_t len, struct sockaddr_in6 *from)
 {

--- a/src/coap/coapserver.c
+++ b/src/coap/coapserver.c
@@ -28,23 +28,29 @@ enum {
   MAX_QUERY_ELEMENTS = 10
 };
 
+#ifndef USE_EXTERNAL_RECV_TASKS
 static osal_task_t recvt_id_task;
+#endif
 static osal_basetype_t m_sockfd = 0;
 static bool m_server_opened = false;
 static recv_handler_t m_recv_handler = NULL;
 
 void send_internal_response(const struct sockaddr_in6 *from, uint16_t tx_id,
                             uint8_t token_length, uint8_t *token, uint16_t status);
+#ifndef USE_EXTERNAL_RECV_TASKS
 #if defined(OSAL_LINUX)
 static void *recv_thread(void* arg);
 #else
 static void recv_thread(void* arg);
 #endif
+#endif
 
 int coapserver_stop()
 {
   m_server_opened = false;
+#ifndef USE_EXTERNAL_RECV_TASKS
   osal_task_cancel(recvt_id_task);
+#endif
   return osal_socket_close(m_sockfd);
 }
 
@@ -52,7 +58,9 @@ int coapserver_listen(uint16_t sport, recv_handler_t recv_handler)
 {
   osal_socket_handle_t sockfd;
   osal_sockaddr_t listen_addr;
+#ifndef USE_EXTERNAL_RECV_TASKS
   osal_basetype_t ret = OSAL_FAILURE;
+#endif
 
   if (m_server_opened) {
     DPRINTF("coapserver_listen coapserver was already opened!\n");
@@ -84,13 +92,16 @@ int coapserver_listen(uint16_t sport, recv_handler_t recv_handler)
 
   m_sockfd = sockfd;
   m_server_opened = true;
+#ifndef USE_EXTERNAL_RECV_TASKS
   ret = osal_task_create(&recvt_id_task, NULL, 0, 0, recv_thread, NULL);
   DPRINTF("coapserver - %s.\n" , (ret == OSAL_SUCCESS) ? "task created" : "task creation failed");
   assert(ret == OSAL_SUCCESS);
+#endif
 
   return 0;
 }
 
+#ifndef USE_EXTERNAL_RECV_TASKS
 #ifdef OSAL_LINUX
 static void *recv_thread(void* arg)
 #else
@@ -134,6 +145,7 @@ static void recv_thread(void* arg)
   return NULL;
 #endif
 }
+#endif
 
 int coapserver_response(const struct sockaddr_in6 *to,
     coap_transaction_type_t tx_type,


### PR DESCRIPTION
## Summary

This PR adds a compile-time option to disable the internal CoAP receive tasks.

When `USE_EXTERNAL_RECV_TASKS` is defined, the CoAP client and server no longer create, cancel, declare, or compile their internal receive tasks. This allows applications or platform integrations to operate the receive handling outside of the library.

## Changes

- Guard the CoAP client receive task declaration with `USE_EXTERNAL_RECV_TASKS`.
- Guard the CoAP client receive task creation in `coapclient_open()`.
- Guard the CoAP client receive task cancellation in `coapclient_stop()`.
- Guard the CoAP client receive task implementation.
- Guard the CoAP server receive task declaration with `USE_EXTERNAL_RECV_TASKS`.
- Guard the CoAP server receive task creation in `coapserver_listen()`.
- Guard the CoAP server receive task cancellation in `coapserver_stop()`.
- Guard the CoAP server receive task implementation.

## Motivation

In some deployments, incoming CoAP packets are received by code outside of the library, for example by an application-specific task, event loop, scheduler, or platform integration layer.

In these cases, the library should not create its own receive tasks. The new compile-time macro makes the internal receive task handling optional while preserving the existing behavior by default.

## Expected behavior

When `USE_EXTERNAL_RECV_TASKS` is not defined, the existing behavior remains unchanged:

- the CoAP client creates its internal receive task,
- the CoAP server creates its internal receive task,
- both tasks are cancelled when the client/server is stopped.

When `USE_EXTERNAL_RECV_TASKS` is defined:

- no internal CoAP receive task is created,
- no internal CoAP receive task is cancelled,
- the internal receive task functions are not compiled,
- receive handling must be provided externally.

## Related issue

Fixes #57 
